### PR TITLE
feat(modules/pbtools): add deepvariant_wgs process (DeepVariant 1.10.0)

### DIFF
--- a/modules/deepvariant/main.nf
+++ b/modules/deepvariant/main.nf
@@ -186,6 +186,46 @@ process glnexus_trio_merge {
 }
 
 
+process deepvariant_wgs {
+    label 'high_memory'
+    tag "${sample_id}"
+    publishDir "${params.deepvariant_output_dir}/${sample_id}", mode: 'copy', overwrite: true
+
+    container "google/deepvariant:1.10.0"
+
+    input:
+    path ref                                                 // Reference genome FASTA
+    path ref_index                                           // Reference FASTA index (.fai) – staged into the work dir so DeepVariant can locate it alongside ref
+    tuple val(sample_id), path(bam), path(bam_index)        // Aligned BAM + BAI – bam_index staged so the BAI is co-located with the BAM
+
+    output:
+    tuple val(sample_id), path("${sample_id}.deepvariant.vcf.gz"), path("${sample_id}.deepvariant.vcf.gz.tbi"), emit: vcf_tuple
+    path "${sample_id}.deepvariant.vcf.gz",       emit: vcf
+    path "${sample_id}.deepvariant.vcf.gz.tbi",   emit: vcf_tbi
+    path "${sample_id}.deepvariant.g.vcf.gz",     emit: gvcf
+    path "${sample_id}.deepvariant.g.vcf.gz.tbi", emit: gvcf_tbi
+
+    script:
+    """
+    /opt/deepvariant/bin/run_deepvariant \\
+        --model_type PACBIO \\
+        --ref ${ref} \\
+        --reads ${bam} \\
+        --output_vcf ${sample_id}.deepvariant.vcf.gz \\
+        --output_gvcf ${sample_id}.deepvariant.g.vcf.gz \\
+        --num_shards ${task.cpus}
+    """
+
+    stub:
+    """
+    touch ${sample_id}.deepvariant.vcf.gz
+    touch ${sample_id}.deepvariant.vcf.gz.tbi
+    touch ${sample_id}.deepvariant.g.vcf.gz
+    touch ${sample_id}.deepvariant.g.vcf.gz.tbi
+    """
+}
+
+
 process deepvariant {
     label 'high_memory'
     tag "${sample_id}"

--- a/modules/pbtools/main.nf
+++ b/modules/pbtools/main.nf
@@ -97,47 +97,10 @@ process pbmm2_align {
     """
 }
 
-process deepvariant_wgs {
-    label 'high_memory'
-    tag "$sample_id"
-    publishDir "${params.deepvariant_output_dir}/${sample_id}", mode: 'copy', overwrite: true
-
-    container "google/deepvariant:1.10.0"
-
-    input:
-    path ref                                                          // Reference genome FASTA
-    path ref_index                                                    // Reference FASTA index (.fai)
-    tuple val(sample_id), path(bam), path(bam_index)                 // Aligned BAM + index
-    val threads                                                       // Number of shards/threads
-
-    output:
-    tuple val(sample_id), path("${sample_id}.deepvariant.vcf.gz"), path("${sample_id}.deepvariant.vcf.gz.tbi"), emit: vcf_tuple
-    path "${sample_id}.deepvariant.vcf.gz",     emit: vcf
-    path "${sample_id}.deepvariant.vcf.gz.tbi", emit: vcf_tbi
-    path "${sample_id}.deepvariant.g.vcf.gz",   emit: gvcf
-    path "${sample_id}.deepvariant.g.vcf.gz.tbi", emit: gvcf_tbi
-
-    script:
-    """
-    /opt/deepvariant/bin/run_deepvariant \\
-        --model_type PACBIO \\
-        --ref ${ref} \\
-        --reads ${bam} \\
-        --output_vcf ${sample_id}.deepvariant.vcf.gz \\
-        --output_gvcf ${sample_id}.deepvariant.g.vcf.gz \\
-        --num_shards ${threads}
-    """
-
-    stub:
-    """
-    touch ${sample_id}.deepvariant.vcf.gz
-    touch ${sample_id}.deepvariant.vcf.gz.tbi
-    touch ${sample_id}.deepvariant.g.vcf.gz
-    touch ${sample_id}.deepvariant.g.vcf.gz.tbi
-    """
-}
-
-
+// Re-export the canonical DeepVariant WGS process from the dedicated
+// DeepVariant module to keep tool ownership consistent and avoid
+// duplicating DeepVariant implementations under pbtools.
+include { deepvariant_wgs } from '../deepvariant/main'
 process hiphase_small_variants {
     /* hiphase small variants only */
 

--- a/modules/pbtools/main.nf
+++ b/modules/pbtools/main.nf
@@ -97,6 +97,47 @@ process pbmm2_align {
     """
 }
 
+process deepvariant_wgs {
+    label 'high_memory'
+    tag "$sample_id"
+    publishDir "${params.deepvariant_output_dir}/${sample_id}", mode: 'copy', overwrite: true
+
+    container "google/deepvariant:1.10.0"
+
+    input:
+    path ref                                                          // Reference genome FASTA
+    path ref_index                                                    // Reference FASTA index (.fai)
+    tuple val(sample_id), path(bam), path(bam_index)                 // Aligned BAM + index
+    val threads                                                       // Number of shards/threads
+
+    output:
+    tuple val(sample_id), path("${sample_id}.deepvariant.vcf.gz"), path("${sample_id}.deepvariant.vcf.gz.tbi"), emit: vcf_tuple
+    path "${sample_id}.deepvariant.vcf.gz",     emit: vcf
+    path "${sample_id}.deepvariant.vcf.gz.tbi", emit: vcf_tbi
+    path "${sample_id}.deepvariant.g.vcf.gz",   emit: gvcf
+    path "${sample_id}.deepvariant.g.vcf.gz.tbi", emit: gvcf_tbi
+
+    script:
+    """
+    /opt/deepvariant/bin/run_deepvariant \\
+        --model_type PACBIO \\
+        --ref ${ref} \\
+        --reads ${bam} \\
+        --output_vcf ${sample_id}.deepvariant.vcf.gz \\
+        --output_gvcf ${sample_id}.deepvariant.g.vcf.gz \\
+        --num_shards ${threads}
+    """
+
+    stub:
+    """
+    touch ${sample_id}.deepvariant.vcf.gz
+    touch ${sample_id}.deepvariant.vcf.gz.tbi
+    touch ${sample_id}.deepvariant.g.vcf.gz
+    touch ${sample_id}.deepvariant.g.vcf.gz.tbi
+    """
+}
+
+
 process hiphase_small_variants {
     /* hiphase small variants only */
 


### PR DESCRIPTION
## Summary

Adds a new `deepvariant_wgs` process to `modules/pbtools/main.nf` for whole-genome variant calling on HiFi-aligned BAM files using **DeepVariant 1.10.0**.

## Changes

- **`modules/pbtools/main.nf`** — new `deepvariant_wgs` process added

## Process details

| Property | Value |
|---|---|
| Container | `google/deepvariant:1.10.0` |
| Model type | `PACBIO` (tuned for HiFi reads) |
| Resource label | `high_memory` (64 GB, 14 CPUs via existing config) |
| Output dir | `params.deepvariant_output_dir/<sample_id>` |

### Inputs
| Name | Type | Description |
|---|---|---|
| `ref` | `path` | Reference genome FASTA |
| `ref_index` | `path` | Reference FASTA index (`.fai`) |
| `[sample_id, bam, bam_index]` | `tuple` | Aligned BAM + BAI from `pbmm2_align` |
| `threads` | `val` | Number of shards / threads |

### Outputs (all emitted with named labels)
| Emit label | File |
|---|---|
| `vcf_tuple` | `(sample_id, .vcf.gz, .vcf.gz.tbi)` |
| `vcf` | `.deepvariant.vcf.gz` |
| `vcf_tbi` | `.deepvariant.vcf.gz.tbi` |
| `gvcf` | `.deepvariant.g.vcf.gz` |
| `gvcf_tbi` | `.deepvariant.g.vcf.gz.tbi` |

## Usage

```nextflow
include { deepvariant_wgs } from './modules/pbtools'

deepvariant_wgs(
    file(params.reference),
    file(params.reference_index),
    pbmm2_align.out.aligned_bam,
    params.deepvariant_threads
)
```

## Testing

The process includes a `stub` block; run a dry-run with:

```bash
nextflow run main.nf -stub-run
```