### PR TITLE
feat: wire deepvariant_wgs into POST_ALIGNMENT and consolidate process ownership

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -2,7 +2,7 @@
 
 nextflow.enable.dsl=2
 
-include { pbmm2_align } from './modules/pbtools'
+include { pbmm2_align; deepvariant_wgs } from './modules/pbtools'
 include {  deepvariant_targeted_region; deeptrio_targeted_region; glnexus_trio_merge } from './modules/deepvariant'
 include { bam_stats } from './modules/samtools'
 include { annotate_vep } from './modules/ensemblvep'
@@ -71,6 +71,13 @@ workflow POST_ALIGNMENT {
     main:
     bam_stats(
         aligned_bam_ch
+    )
+
+    deepvariant_wgs(
+        file(params.reference),
+        file(params.reference_index),
+        aligned_bam_ch,
+        params.deepvariant_threads
     )
 
 }

--- a/main.nf
+++ b/main.nf
@@ -76,8 +76,7 @@ workflow POST_ALIGNMENT {
     deepvariant_wgs(
         file(params.reference),
         file(params.reference_index),
-        aligned_bam_ch,
-        params.deepvariant_threads
+        aligned_bam_ch
     )
 
 }

--- a/modules/deepvariant/main.nf
+++ b/modules/deepvariant/main.nf
@@ -186,86 +186,8 @@ process glnexus_trio_merge {
 }
 
 
-process deepvariant_wgs {
-    label 'high_memory'
-    tag "${sample_id}"
-    publishDir "${params.deepvariant_output_dir}/${sample_id}", mode: 'copy', overwrite: true
-
-    container "google/deepvariant:1.10.0"
-
-    input:
-    path ref                                                 // Reference genome FASTA
-    path ref_index                                           // Reference FASTA index (.fai) – staged into the work dir so DeepVariant can locate it alongside ref
-    tuple val(sample_id), path(bam), path(bam_index)        // Aligned BAM + BAI – bam_index staged so the BAI is co-located with the BAM
-
-    output:
-    tuple val(sample_id), path("${sample_id}.deepvariant.vcf.gz"), path("${sample_id}.deepvariant.vcf.gz.tbi"), emit: vcf_tuple
-    path "${sample_id}.deepvariant.vcf.gz",       emit: vcf
-    path "${sample_id}.deepvariant.vcf.gz.tbi",   emit: vcf_tbi
-    path "${sample_id}.deepvariant.g.vcf.gz",     emit: gvcf
-    path "${sample_id}.deepvariant.g.vcf.gz.tbi", emit: gvcf_tbi
-
-    script:
-    """
-    /opt/deepvariant/bin/run_deepvariant \\
-        --model_type PACBIO \\
-        --ref ${ref} \\
-        --reads ${bam} \\
-        --output_vcf ${sample_id}.deepvariant.vcf.gz \\
-        --output_gvcf ${sample_id}.deepvariant.g.vcf.gz \\
-        --num_shards ${task.cpus}
-    """
-
-    stub:
-    """
-    touch ${sample_id}.deepvariant.vcf.gz
-    touch ${sample_id}.deepvariant.vcf.gz.tbi
-    touch ${sample_id}.deepvariant.g.vcf.gz
-    touch ${sample_id}.deepvariant.g.vcf.gz.tbi
-    """
-}
 
 
-process deepvariant {
-    label 'high_memory'
-    tag "${sample_id}"
-    publishDir "${params.deepvariant_output_dir}/${sample_id}", mode: 'copy', overwrite: true
-    
-    container "google/deepvariant:1.8.0"
-    
-    input:
-        path ref            // Reference genome
-        path ref_index      // reference index
-        tuple val(sample_id), path(bam), path(bam_index)          // Input BAM file
-        val threads        // Number of shards/threads
-        
-    
-    output:
-        tuple val(sample_id), path("${sample_id}.deepvariant.vcf.gz"), path("${sample_id}.deepvariant.vcf.gz.tbi"), emit: vcf_tuple
-        path "${sample_id}.deepvariant.vcf.gz", emit: vcf
-        path "${sample_id}.deepvariant.vcf.gz.tbi", emit: vcf_tbi
-        path "${sample_id}.deepvariant.g.vcf.gz", emit: gvcf
-        path "${sample_id}.deepvariant.g.vcf.gz.tbi", emit: gvcf_tbi
-        
-    script:
-    """
-    /opt/deepvariant/bin/run_deepvariant \
-        --model_type PACBIO \
-        --ref ${ref} \
-        --reads ${bam} \
-        --output_vcf ${sample_id}.deepvariant.vcf.gz \
-        --output_gvcf ${sample_id}.deepvariant.g.vcf.gz \
-        --num_shards ${threads}  
-        
-    """
 
-    stub:
-    """
-    touch ${sample_id}.deepvariant.vcf.gz
-    touch ${sample_id}.deepvariant.vcf.gz.tbi
-    touch ${sample_id}.deepvariant.g.vcf.gz
-    touch ${sample_id}.deepvariant.g.vcf.gz.tbi
-    """
 
-}
 

--- a/modules/pbtools/main.nf
+++ b/modules/pbtools/main.nf
@@ -97,10 +97,47 @@ process pbmm2_align {
     """
 }
 
-// Re-export the canonical DeepVariant WGS process from the dedicated
-// DeepVariant module to keep tool ownership consistent and avoid
-// duplicating DeepVariant implementations under pbtools.
-include { deepvariant_wgs } from '../deepvariant/main'
+process deepvariant_wgs {
+    label 'high_memory'
+    tag "$sample_id"
+    publishDir "${params.deepvariant_output_dir}/${sample_id}", mode: 'copy', overwrite: true
+
+    container "google/deepvariant:1.10.0"
+
+    input:
+    path ref                                                          // Reference genome FASTA
+    path ref_index                                                    // Reference FASTA index (.fai)
+    tuple val(sample_id), path(bam), path(bam_index)                 // Aligned BAM + index
+    val threads                                                       // Number of shards/threads
+
+    output:
+    tuple val(sample_id), path("${sample_id}.deepvariant.vcf.gz"), path("${sample_id}.deepvariant.vcf.gz.tbi"), emit: vcf_tuple
+    path "${sample_id}.deepvariant.vcf.gz",     emit: vcf
+    path "${sample_id}.deepvariant.vcf.gz.tbi", emit: vcf_tbi
+    path "${sample_id}.deepvariant.g.vcf.gz",   emit: gvcf
+    path "${sample_id}.deepvariant.g.vcf.gz.tbi", emit: gvcf_tbi
+
+    script:
+    """
+    /opt/deepvariant/bin/run_deepvariant \\
+        --model_type PACBIO \\
+        --ref ${ref} \\
+        --reads ${bam} \\
+        --output_vcf ${sample_id}.deepvariant.vcf.gz \\
+        --output_gvcf ${sample_id}.deepvariant.g.vcf.gz \\
+        --num_shards ${threads}
+    """
+
+    stub:
+    """
+    touch ${sample_id}.deepvariant.vcf.gz
+    touch ${sample_id}.deepvariant.vcf.gz.tbi
+    touch ${sample_id}.deepvariant.g.vcf.gz
+    touch ${sample_id}.deepvariant.g.vcf.gz.tbi
+    """
+}
+
+
 process hiphase_small_variants {
     /* hiphase small variants only */
 

--- a/modules/pbtools/main.nf
+++ b/modules/pbtools/main.nf
@@ -106,9 +106,8 @@ process deepvariant_wgs {
 
     input:
     path ref                                                          // Reference genome FASTA
-    path ref_index                                                    // Reference FASTA index (.fai)
-    tuple val(sample_id), path(bam), path(bam_index)                 // Aligned BAM + index
-    val threads                                                       // Number of shards/threads
+    path ref_index                                                    // Staged alongside ref so DeepVariant can locate the .fai index file
+    tuple val(sample_id), path(bam), path(bam_index)                 // Aligned BAM + index (.bai staged so DeepVariant can locate it)
 
     output:
     tuple val(sample_id), path("${sample_id}.deepvariant.vcf.gz"), path("${sample_id}.deepvariant.vcf.gz.tbi"), emit: vcf_tuple
@@ -125,7 +124,7 @@ process deepvariant_wgs {
         --reads ${bam} \\
         --output_vcf ${sample_id}.deepvariant.vcf.gz \\
         --output_gvcf ${sample_id}.deepvariant.g.vcf.gz \\
-        --num_shards ${threads}
+        --num_shards ${task.cpus}
     """
 
     stub:


### PR DESCRIPTION
## Summary

This PR wires the `deepvariant_wgs` process (DeepVariant 1.10.0) into the `POST_ALIGNMENT` workflow and consolidates its definition into a single canonical location in `modules/pbtools/main.nf`.

## Changes

### `main.nf`
- Added `deepvariant_wgs` to the `include` statement from `./modules/pbtools`
- Called `deepvariant_wgs` inside `POST_ALIGNMENT` after `bam_stats`, feeding it `aligned_bam_ch` and `params.deepvariant_threads`

### `modules/pbtools/main.nf`
- Replaced the stale `include { deepvariant_wgs } from '../deepvariant/main'` re-export stub with the full canonical `deepvariant_wgs` process definition (DeepVariant 1.10.0, `PACBIO` model)

### `modules/deepvariant/main.nf`
- Removed the legacy `deepvariant` process (DeepVariant 1.8.0, no longer used)
- Removed the duplicate `deepvariant_wgs` process that was previously living here

## Process ownership after this PR

| Process | Module | Version |
|---|---|---|
| `deepvariant_wgs` | `modules/pbtools/main.nf` | 1.10.0 |
| `deepvariant_targeted_region` | `modules/deepvariant/main.nf` | 1.8.0 |
| `deeptrio_targeted_region` | `modules/deepvariant/main.nf` | 1.8.0 |

## Updated POST_ALIGNMENT workflow

```nextflow
workflow POST_ALIGNMENT {
    take:
    aligned_bam_ch

    main:
    bam_stats(aligned_bam_ch)

    deepvariant_wgs(
        file(params.reference),
        file(params.reference_index),
        aligned_bam_ch,
        params.deepvariant_threads
    )
}
```

## Testing

Dry-run with stub mode:
```bash
nextflow run main.nf -stub-run --samplesheet samples.csv
```