### PR TITLE
feat: add 5mC CpG methylation calling process (pb-cpg-tools v3.0.0)

### DIFF
--- a/modules/pbtools/main.nf
+++ b/modules/pbtools/main.nf
@@ -100,6 +100,57 @@ process pbmm2_align {
 
 
 
+process cpg_methylation_calling {
+    /*
+     * 5mC CpG methylation calling from HiFi-aligned BAM using pb-CpG-tools.
+     *
+     * Assumes a non-haplotagged BAM, so only combined (all-reads) outputs are
+     * produced. For haplotagged BAMs, hap1/hap2 bed/bw files would also be
+     * emitted — add those to the output block if haplotype tracks are needed.
+     *
+     * Recommended defaults (model pileup + denovo modsites) are used.
+     * --min-mapq 20 and --min-coverage 10 are applied as requested.
+     */
+
+    label 'high_memory'
+    tag "$sample_id"
+    publishDir "${params.cpg_output_dir}/${sample_id}", mode: 'copy', overwrite: true
+
+    container "quay.io/pacbio/pb-cpg-tools:3.0.0_build1"
+
+    input:
+    tuple val(sample_id), path(bam), path(bam_index)  // Aligned (non-haplotagged) BAM + BAI
+    path ref                                           // Reference genome FASTA (required for CRAM; staged for BAM)
+    path ref_index                                     // Reference FASTA index (.fai)
+
+    output:
+    tuple val(sample_id),
+          path("${sample_id}.combined.bed.gz"),
+          path("${sample_id}.combined.bed.gz.tbi"), emit: combined_bed
+    path "${sample_id}.combined.bw",                 emit: combined_bw
+
+    script:
+    """
+    aligned_bam_to_cpg_scores \\
+        --bam ${bam} \\
+        --output-prefix ${sample_id} \\
+        --ref ${ref} \\
+        --pileup-mode model \\
+        --modsites-mode denovo \\
+        --min-mapq 20 \\
+        --min-coverage 10 \\
+        --threads ${task.cpus}
+    """
+
+    stub:
+    """
+    touch ${sample_id}.combined.bed.gz
+    touch ${sample_id}.combined.bed.gz.tbi
+    touch ${sample_id}.combined.bw
+    """
+}
+
+
 process hiphase_small_variants {
     /* hiphase small variants only */
 

--- a/modules/pbtools/main.nf
+++ b/modules/pbtools/main.nf
@@ -127,7 +127,7 @@ process cpg_methylation_calling {
     tuple val(sample_id),
           path("${sample_id}.combined.bed.gz"),
           path("${sample_id}.combined.bed.gz.tbi"), emit: combined_bed
-    path "${sample_id}.combined.bw",                 emit: combined_bw
+    tuple val(sample_id), path("${sample_id}.combined.bw"), emit: combined_bw
 
     script:
     """

--- a/modules/pbtools/main.nf
+++ b/modules/pbtools/main.nf
@@ -114,7 +114,7 @@ process cpg_methylation_calling {
 
     label 'high_memory'
     tag "$sample_id"
-    publishDir "${params.cpg_output_dir}/${sample_id}", mode: 'copy', overwrite: true
+    publishDir "${((params.cpg_output_dir ?: '').toString().trim()) ? "${params.cpg_output_dir}/${sample_id}" : error("Missing required parameter: --cpg_output_dir. Set params.cpg_output_dir in nextflow.config or pass --cpg_output_dir on the command line.")}", mode: 'copy', overwrite: true
 
     container "quay.io/pacbio/pb-cpg-tools:3.0.0_build1"
 


### PR DESCRIPTION
## Summary

Adds a `cpg_methylation_calling` Nextflow process to `modules/pbtools/main.nf` for 5mC site methylation probability calling from HiFi-aligned BAMs using **pb-CpG-tools v3.0.0**.

## Process details

| Property | Value |
|---|---|
| Container | `quay.io/pacbio/pb-cpg-tools:3.0.0_build1` |
| Tool | `aligned_bam_to_cpg_scores` |
| Pileup mode | `model` (ML-based default, recommended) |
| Modsites mode | `denovo` (all CpG sites from read consensus) |
| `--min-mapq` | 20 |
| `--min-coverage` | 10 |
| Threads | `task.cpus` |

## Inputs

```
tuple val(sample_id), path(bam), path(bam_index)  // Aligned (non-haplotagged) BAM + BAI
path ref                                           // Reference FASTA
path ref_index                                     // Reference FASTA index (.fai)
```

Input BAM is assumed to be **non-haplotagged**, so only combined (all-reads) outputs are produced. If haplotagged BAMs are used in the future, `hap1`/`hap2` bed+bw outputs can be added to the `output` block.

## Outputs

| Emit name | Files | Description |
|---|---|---|
| `combined_bed` | `*.combined.bed.gz` + `.tbi` | bgzipped bed + tabix index |
| `combined_bw` | `*.combined.bw` | BigWig for IGV visualisation |

## Configuration

Add `params.cpg_output_dir` to `nextflow.config` / your params file, e.g.:

```groovy
params.cpg_output_dir = "${baseDir}/results/cpg"
```

## Usage in a workflow

```nextflow
include { cpg_methylation_calling } from './modules/pbtools'

workflow POST_ALIGNMENT {
    // ...existing alignment steps...

    cpg_methylation_calling(
        aligned_bam_ch,           // tuple(sample_id, bam, bai)
        file(params.reference),
        file(params.reference_index)
    )
}
```

## Testing

A `stub` block is included so the process can be exercised with `-stub-run` / dry-run without a real BAM.
