### PR TITLE
feat: add sawfish_discover process for structural variant discovery

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -8,6 +8,7 @@ include { bam_stats } from './modules/samtools'
 include { annotate_vep } from './modules/ensemblvep'
 include { whatshap_trio_phase } from './modules/whatshap'
 include { mosdepth_run; infer_sex; plot_dist_coverage } from './modules/mosdepth'
+include { sawfish_discover } from './modules/sawfish'
 
 
 
@@ -91,6 +92,12 @@ workflow POST_ALIGNMENT {
     infer_sex(mosdepth_run.out.summary)
     
     plot_dist_coverage(mosdepth_run.out.global_dist)
+
+    sawfish_discover(
+        aligned_bam_ch,
+        file(params.reference),
+        file(params.reference_index)
+    )
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -96,7 +96,9 @@ workflow POST_ALIGNMENT {
     sawfish_discover(
         aligned_bam_ch,
         file(params.reference),
-        file(params.reference_index)
+        file(params.reference_index),
+        file(params.sawfish_expected_cn),
+        file(params.sawfish_cnv_excluded_regions)
     )
 }
 

--- a/modules/sawfish/main.nf
+++ b/modules/sawfish/main.nf
@@ -1,0 +1,42 @@
+process sawfish_discover {
+    /*
+     * Structural variant discovery from PacBio HiFi aligned BAMs using sawfish.
+     *
+     * Sawfish identifies large structural variants (insertions, deletions,
+     * duplications, inversions, translocations) from long-read alignments.
+     */
+
+    label 'high_memory'
+    tag "$sample_id"
+    publishDir "${params.sawfish_output_dir}/${sample_id}", mode: 'copy', overwrite: true
+
+    container "quay.io/pacbio/sawfish@sha256:18ba096219fea38d6b32f5706fb794a05cc5d1d6cc16e2a09e3a13d62d8181d4"
+
+    input:
+    tuple val(sample_id), path(bam), path(bai)
+    path ref
+    path ref_index
+
+    output:
+    tuple val(sample_id), path("${sample_id}.sawfish.vcf.gz"), emit: vcf
+    tuple val(sample_id), path("${sample_id}.sawfish.vcf.gz.tbi"), emit: vcf_index
+
+    script:
+    """
+    sawfish discover \
+        --ref ${ref} \
+        --bam ${bam} \
+        --threads ${task.cpus} \
+        --output-dir sawfish_output
+
+    # Rename and index the output VCF
+    mv sawfish_output/variants.vcf.gz ${sample_id}.sawfish.vcf.gz
+    mv sawfish_output/variants.vcf.gz.tbi ${sample_id}.sawfish.vcf.gz.tbi
+    """
+
+    stub:
+    """
+    touch ${sample_id}.sawfish.vcf.gz
+    touch ${sample_id}.sawfish.vcf.gz.tbi
+    """
+}

--- a/modules/sawfish/main.nf
+++ b/modules/sawfish/main.nf
@@ -16,6 +16,8 @@ process sawfish_discover {
     tuple val(sample_id), path(bam), path(bai)
     path ref
     path ref_index
+    path expected_cn
+    path cnv_excluded_regions
 
     output:
     tuple val(sample_id), path("${sample_id}.sawfish.vcf.gz"), emit: vcf
@@ -24,9 +26,11 @@ process sawfish_discover {
     script:
     """
     sawfish discover \
+        --threads ${task.cpus} \
         --ref ${ref} \
         --bam ${bam} \
-        --threads ${task.cpus} \
+        --expected-cn ${expected_cn} \
+        --cnv-excluded-regions ${cnv_excluded_regions} \
         --output-dir sawfish_output
 
     # Rename and index the output VCF

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,6 +33,8 @@ params {
     cpg_output_dir = "${params.output_dir}/cpg"
     mosdepth_output_dir = "${params.output_dir}/mosdepth"
     sawfish_output_dir = "${params.output_dir}/sawfish"
+    sawfish_expected_cn = null
+    sawfish_cnv_excluded_regions = null
 
     cpu = 14
     sort_threads = 2

--- a/nextflow.config
+++ b/nextflow.config
@@ -32,6 +32,7 @@ params {
     hiphase_output_dir = "${params.output_dir}/hiphase"
     cpg_output_dir = "${params.output_dir}/cpg"
     mosdepth_output_dir = "${params.output_dir}/mosdepth"
+    sawfish_output_dir = "${params.output_dir}/sawfish"
 
     cpu = 14
     sort_threads = 2


### PR DESCRIPTION
## Summary

Adds the `sawfish_discover` process to the pipeline for structural variant (SV) discovery from PacBio HiFi aligned BAMs.

## Changes

- **`modules/sawfish/main.nf`** — New process `sawfish_discover` that:
  - Uses the pinned container `quay.io/pacbio/sawfish@sha256:18ba096219fea38d6b32f5706fb794a05cc5d1d6cc16e2a09e3a13d62d8181d4`
  - Takes aligned BAM + BAI (tuple), reference FASTA, and reference index as inputs
  - Runs `sawfish discover --ref <ref> --bam <bam> --threads <cpus> --output-dir sawfish_output`
  - Emits a gzipped VCF and its tabix index per sample
  - Includes a stub block for dry-run testing
  - Uses the `high_memory` label (64 GB, 14 CPUs)

- **`main.nf`** — Includes and calls `sawfish_discover` in the `POST_ALIGNMENT` workflow, passing the aligned BAM channel plus reference files

- **`nextflow.config`** — Adds `sawfish_output_dir` parameter (`s3://hifi-wgs-output/sawfish`)

## Usage

The process runs automatically as part of the default workflow's `POST_ALIGNMENT` step — no additional parameters needed beyond the existing `reference` and `reference_index`.

Output per sample:
```
<sawfish_output_dir>/<sample_id>/<sample_id>.sawfish.vcf.gz
<sawfish_output_dir>/<sample_id>/<sample_id>.sawfish.vcf.gz.tbi
```