### PR TITLE
feat: scatter DeepTrio WGS by chromosome and merge per-sample VCFs

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -191,16 +191,16 @@ workflow WGS_TRIO {
 
     // Tag merged VCFs with roles
     merged_vcf_with_role = bcftools_concat_deeptrio_vcfs.out.merged_vcf
-        .map { fam, sample_id, vcf, tbi -> tuple([fam, sample_id].toString(), fam, sample_id, vcf, tbi) }
+        .map { fam, sample_id, vcf, tbi -> tuple([fam, sample_id], fam, sample_id, vcf, tbi) }
         .join(
-            trio_roles_ch.map { fam, sample_id, role -> tuple([fam, sample_id].toString(), role) }
+            trio_roles_ch.map { fam, sample_id, role -> tuple([fam, sample_id], role) }
         )
         .map { key, fam, sample_id, vcf, tbi, role -> tuple(fam, sample_id, vcf, tbi, role) }
 
     merged_gvcf_with_role = bcftools_concat_deeptrio_gvcfs.out.merged_gvcf
-        .map { fam, sample_id, gvcf, tbi -> tuple([fam, sample_id].toString(), fam, sample_id, gvcf, tbi) }
+        .map { fam, sample_id, gvcf, tbi -> tuple([fam, sample_id], fam, sample_id, gvcf, tbi) }
         .join(
-            trio_roles_ch.map { fam, sample_id, role -> tuple([fam, sample_id].toString(), role) }
+            trio_roles_ch.map { fam, sample_id, role -> tuple([fam, sample_id], role) }
         )
         .map { key, fam, sample_id, gvcf, tbi, role -> tuple(fam, sample_id, gvcf, tbi, role) }
 

--- a/main.nf
+++ b/main.nf
@@ -3,7 +3,7 @@
 nextflow.enable.dsl=2
 
 include { pbmm2_align; cpg_methylation_calling; sawfish_discover; sawfish_joint_call; hiphase_small_variants } from './modules/pbtools'
-include { glnexus_trio_merge; deeptrio_wgs; deepvariant_wgs } from './modules/deepvariant'
+include { glnexus_trio_merge; deeptrio_wgs; deeptrio_wgs_by_chrom; bcftools_concat_deeptrio_vcfs; bcftools_concat_deeptrio_gvcfs; deepvariant_wgs } from './modules/deepvariant'
 include { bam_stats } from './modules/samtools'
 include { whatshap_trio_phase } from './modules/whatshap'
 include { mosdepth_run; infer_sex; plot_dist_coverage } from './modules/mosdepth'
@@ -121,19 +121,106 @@ workflow WGS_TRIO {
             tuple(fam, c_id, c_bam, c_bai, p1_id, p1_bam, p1_bai, p2_id, p2_bam, p2_bai)
         }
 
-    // 5. Run DeepTrio
-    deeptrio_wgs(file(params.reference), file(params.reference_index), deeptrio_input_ch)
+    // 5. Run DeepTrio by chromosome (scatter-gather)
+    // Create a channel of chromosomes to scatter over
+    def chromosomes_ch = channel.of(
+        'chr1', 'chr2', 'chr3', 'chr4', 'chr5', 'chr6',
+        'chr7', 'chr8', 'chr9', 'chr10', 'chr11', 'chr12',
+        'chr13', 'chr14', 'chr15', 'chr16', 'chr17', 'chr18',
+        'chr19', 'chr20', 'chr21', 'chr22', 'chrX', 'chrY'
+    )
 
-    // GLNexus merge
-    // Reconstruct the merged input tuple grouped by family_id
-    glnexus_input_ch = deeptrio_wgs.out.child_gvcf
-        // Join Child with Parent 1 on family_id (the first element)
-        .join(deeptrio_wgs.out.p1_gvcf) 
-        // Current state: [fam, child_id, child_gvcf, child_tbi, p1_id, p1_gvcf, p1_tbi]
-        
-        // Join the result with Parent 2 on family_id
-        .join(deeptrio_wgs.out.p2_gvcf)
-        // Current state: [fam, child_id, child_gvcf, child_tbi, p1_id, p1_gvcf, p1_tbi, p2_id, p2_gvcf, p2_tbi]
+    // Scatter: combine each trio with each chromosome
+    deeptrio_scatter_ch = deeptrio_input_ch.combine(chromosomes_ch)
+    // Shape: [fam, child_id, child_bam, child_bai, p1_id, p1_bam, p1_bai, p2_id, p2_bam, p2_bai, chrom]
+
+    // Run DeepTrio per chromosome
+    deeptrio_wgs_by_chrom(
+        file(params.reference),
+        file(params.reference_index),
+        deeptrio_scatter_ch.map { it[0..9] },  // trio tuple
+        deeptrio_scatter_ch.map { it[10] }      // chrom
+    )
+
+    // Gather: collect per-chromosome VCFs per sample and merge
+    // Child VCFs: [family_id, child_id, chrom, vcf, tbi] -> group by [family_id, sample_id]
+    child_vcfs_grouped = deeptrio_wgs_by_chrom.out.child_vcf
+        .map { family_id, sample_id, chrom, vcf, tbi -> tuple(family_id, sample_id, vcf, tbi) }
+        .groupTuple(by: [0, 1], size: 24)
+
+    child_gvcfs_grouped = deeptrio_wgs_by_chrom.out.child_gvcf
+        .map { family_id, sample_id, chrom, gvcf, tbi -> tuple(family_id, sample_id, gvcf, tbi) }
+        .groupTuple(by: [0, 1], size: 24)
+
+    p1_vcfs_grouped = deeptrio_wgs_by_chrom.out.p1_vcf
+        .map { family_id, sample_id, chrom, vcf, tbi -> tuple(family_id, sample_id, vcf, tbi) }
+        .groupTuple(by: [0, 1], size: 24)
+
+    p1_gvcfs_grouped = deeptrio_wgs_by_chrom.out.p1_gvcf
+        .map { family_id, sample_id, chrom, gvcf, tbi -> tuple(family_id, sample_id, gvcf, tbi) }
+        .groupTuple(by: [0, 1], size: 24)
+
+    p2_vcfs_grouped = deeptrio_wgs_by_chrom.out.p2_vcf
+        .map { family_id, sample_id, chrom, vcf, tbi -> tuple(family_id, sample_id, vcf, tbi) }
+        .groupTuple(by: [0, 1], size: 24)
+
+    p2_gvcfs_grouped = deeptrio_wgs_by_chrom.out.p2_gvcf
+        .map { family_id, sample_id, chrom, gvcf, tbi -> tuple(family_id, sample_id, gvcf, tbi) }
+        .groupTuple(by: [0, 1], size: 24)
+
+    // Merge all per-sample VCFs (child + parents)
+    all_vcfs_to_merge = child_vcfs_grouped.mix(p1_vcfs_grouped, p2_vcfs_grouped)
+    all_gvcfs_to_merge = child_gvcfs_grouped.mix(p1_gvcfs_grouped, p2_gvcfs_grouped)
+
+    bcftools_concat_deeptrio_vcfs(all_vcfs_to_merge)
+    bcftools_concat_deeptrio_gvcfs(all_gvcfs_to_merge)
+
+    // Reconstruct family-level outputs for downstream (GLnexus, WhatsHap)
+    // merged_vcf emits: [family_id, sample_id, vcf, tbi]
+    // merged_gvcf emits: [family_id, sample_id, gvcf, tbi]
+
+    // Separate merged outputs back into child/parent channels using the trio metadata
+    // We need to rejoin with the original trio structure to identify roles
+    trio_roles_ch = deeptrio_input_ch.flatMap { fam, c_id, c_bam, c_bai, p1_id, p1_bam, p1_bai, p2_id, p2_bam, p2_bai ->
+        [
+            tuple(fam, c_id, 'child'),
+            tuple(fam, p1_id, 'parent1'),
+            tuple(fam, p2_id, 'parent2')
+        ]
+    }
+
+    // Tag merged VCFs with roles
+    merged_vcf_with_role = bcftools_concat_deeptrio_vcfs.out.merged_vcf
+        .map { fam, sample_id, vcf, tbi -> tuple([fam, sample_id].toString(), fam, sample_id, vcf, tbi) }
+        .join(
+            trio_roles_ch.map { fam, sample_id, role -> tuple([fam, sample_id].toString(), role) }
+        )
+        .map { key, fam, sample_id, vcf, tbi, role -> tuple(fam, sample_id, vcf, tbi, role) }
+
+    merged_gvcf_with_role = bcftools_concat_deeptrio_gvcfs.out.merged_gvcf
+        .map { fam, sample_id, gvcf, tbi -> tuple([fam, sample_id].toString(), fam, sample_id, gvcf, tbi) }
+        .join(
+            trio_roles_ch.map { fam, sample_id, role -> tuple([fam, sample_id].toString(), role) }
+        )
+        .map { key, fam, sample_id, gvcf, tbi, role -> tuple(fam, sample_id, gvcf, tbi, role) }
+
+    // Split into role-specific channels for GLnexus
+    child_gvcf_merged = merged_gvcf_with_role
+        .filter { fam, sample_id, gvcf, tbi, role -> role == 'child' }
+        .map { fam, sample_id, gvcf, tbi, role -> tuple(fam, sample_id, gvcf, tbi) }
+
+    p1_gvcf_merged = merged_gvcf_with_role
+        .filter { fam, sample_id, gvcf, tbi, role -> role == 'parent1' }
+        .map { fam, sample_id, gvcf, tbi, role -> tuple(fam, sample_id, gvcf, tbi) }
+
+    p2_gvcf_merged = merged_gvcf_with_role
+        .filter { fam, sample_id, gvcf, tbi, role -> role == 'parent2' }
+        .map { fam, sample_id, gvcf, tbi, role -> tuple(fam, sample_id, gvcf, tbi) }
+
+    // GLNexus merge: reconstruct the input tuple grouped by family_id
+    glnexus_input_ch = child_gvcf_merged
+        .join(p1_gvcf_merged)
+        .join(p2_gvcf_merged)
 
     // Run GLnexus
     glnexus_trio_merge(glnexus_input_ch)
@@ -159,11 +246,11 @@ workflow WGS_TRIO {
     )
 
     // 1. Gather all parent VCFs into a single channel and format to [sample_id, vcf, vcf_tbi]
-    // deeptrio_wgs.out.p1_vcf / p2_vcf are: [family_id, parent_id, vcf, vcf_tbi]
-    parent_vcfs_ch = deeptrio_wgs.out.p1_vcf
-        .mix(deeptrio_wgs.out.p2_vcf)
-        .map { family_id, parent_id, vcf, vcf_tbi -> 
-            tuple(parent_id, vcf, vcf_tbi) 
+    // Use merged per-sample VCFs from bcftools_concat, filtered to parent roles
+    parent_vcfs_ch = merged_vcf_with_role
+        .filter { fam, sample_id, vcf, tbi, role -> role == 'parent1' || role == 'parent2' }
+        .map { fam, sample_id, vcf, tbi, role -> 
+            tuple(sample_id, vcf, tbi) 
         }
 
     // 2. Join the parent VCFs with their corresponding individual aligned BAMs

--- a/modules/deepvariant/main.nf
+++ b/modules/deepvariant/main.nf
@@ -210,11 +210,21 @@ process bcftools_concat_deeptrio_vcfs {
 
     script:
     """
+    # Build file list in genomic chromosome order
+    # Filenames follow the pattern: {sample_id}.{chrom}.vcf.gz
+    for chrom in chr1 chr2 chr3 chr4 chr5 chr6 chr7 chr8 chr9 chr10 \
+                 chr11 chr12 chr13 chr14 chr15 chr16 chr17 chr18 chr19 chr20 \
+                 chr21 chr22 chrX chrY; do
+        if [ -f "${sample_id}.\${chrom}.vcf.gz" ]; then
+            echo "${sample_id}.\${chrom}.vcf.gz" >> vcf_list.txt
+        fi
+    done
+
     bcftools concat \
         --allow-overlaps \
+        --file-list vcf_list.txt \
         -Oz \
-        -o ${sample_id}.vcf.gz \
-        ${vcfs}
+        -o ${sample_id}.vcf.gz
 
     bcftools index -t ${sample_id}.vcf.gz
     """
@@ -241,11 +251,21 @@ process bcftools_concat_deeptrio_gvcfs {
 
     script:
     """
+    # Build file list in genomic chromosome order
+    # Filenames follow the pattern: {sample_id}.{chrom}.g.vcf.gz
+    for chrom in chr1 chr2 chr3 chr4 chr5 chr6 chr7 chr8 chr9 chr10 \
+                 chr11 chr12 chr13 chr14 chr15 chr16 chr17 chr18 chr19 chr20 \
+                 chr21 chr22 chrX chrY; do
+        if [ -f "${sample_id}.\${chrom}.g.vcf.gz" ]; then
+            echo "${sample_id}.\${chrom}.g.vcf.gz" >> gvcf_list.txt
+        fi
+    done
+
     bcftools concat \
         --allow-overlaps \
+        --file-list gvcf_list.txt \
         -Oz \
-        -o ${sample_id}.g.vcf.gz \
-        ${gvcfs}
+        -o ${sample_id}.g.vcf.gz
 
     bcftools index -t ${sample_id}.g.vcf.gz
     """

--- a/modules/deepvariant/main.nf
+++ b/modules/deepvariant/main.nf
@@ -167,9 +167,10 @@ process deeptrio_wgs_by_chrom {
         tuple val(family_id), val(p2_id), val(chrom), path("${p2_id}.${chrom}.g.vcf.gz"), path("${p2_id}.${chrom}.g.vcf.gz.tbi"), emit: p2_gvcf
 
     script:
+    def model_type = task.ext.model_type ?: 'PACBIO'
     """
     /opt/deepvariant/bin/deeptrio/run_deeptrio \
-        --model_type PACBIO \
+        --model_type ${model_type} \
         --ref ${ref} \
         --reads_child ${child_bam} \
         --reads_parent1 ${p1_bam} \

--- a/modules/deepvariant/main.nf
+++ b/modules/deepvariant/main.nf
@@ -143,6 +143,121 @@ process deeptrio_wgs {
     """
 }
 
+process deeptrio_wgs_by_chrom {
+    tag { "${family_id}_${chrom}" }
+    publishDir { "${params.deepvariant_output_dir}/DV_trio/${family_id}/by_chrom" }, mode: 'copy', overwrite: true
+
+    container "google/deepvariant:deeptrio-1.10.0"
+
+    input:
+        path ref
+        path ref_index
+        tuple val(family_id), \
+              val(child_id), path(child_bam), path(child_bai), \
+              val(p1_id),    path(p1_bam),    path(p1_bai), \
+              val(p2_id),    path(p2_bam),    path(p2_bai)
+        val(chrom)
+
+    output:
+        tuple val(family_id), val(child_id), val(chrom), path("${child_id}.${chrom}.vcf.gz"), path("${child_id}.${chrom}.vcf.gz.tbi"), emit: child_vcf
+        tuple val(family_id), val(child_id), val(chrom), path("${child_id}.${chrom}.g.vcf.gz"), path("${child_id}.${chrom}.g.vcf.gz.tbi"), emit: child_gvcf
+        tuple val(family_id), val(p1_id), val(chrom), path("${p1_id}.${chrom}.vcf.gz"), path("${p1_id}.${chrom}.vcf.gz.tbi"), emit: p1_vcf
+        tuple val(family_id), val(p1_id), val(chrom), path("${p1_id}.${chrom}.g.vcf.gz"), path("${p1_id}.${chrom}.g.vcf.gz.tbi"), emit: p1_gvcf
+        tuple val(family_id), val(p2_id), val(chrom), path("${p2_id}.${chrom}.vcf.gz"), path("${p2_id}.${chrom}.vcf.gz.tbi"), emit: p2_vcf
+        tuple val(family_id), val(p2_id), val(chrom), path("${p2_id}.${chrom}.g.vcf.gz"), path("${p2_id}.${chrom}.g.vcf.gz.tbi"), emit: p2_gvcf
+
+    script:
+    """
+    /opt/deepvariant/bin/deeptrio/run_deeptrio \
+        --model_type PACBIO \
+        --ref ${ref} \
+        --reads_child ${child_bam} \
+        --reads_parent1 ${p1_bam} \
+        --reads_parent2 ${p2_bam} \
+        --sample_name_child "${child_id}" \
+        --sample_name_parent1 "${p1_id}" \
+        --sample_name_parent2 "${p2_id}" \
+        --output_vcf_child ${child_id}.${chrom}.vcf.gz \
+        --output_vcf_parent1 ${p1_id}.${chrom}.vcf.gz \
+        --output_vcf_parent2 ${p2_id}.${chrom}.vcf.gz \
+        --output_gvcf_child ${child_id}.${chrom}.g.vcf.gz \
+        --output_gvcf_parent1 ${p1_id}.${chrom}.g.vcf.gz \
+        --output_gvcf_parent2 ${p2_id}.${chrom}.g.vcf.gz \
+        --num_shards ${task.cpus} \
+        --regions ${chrom}
+    """
+
+    stub:
+    """
+    touch ${child_id}.${chrom}.vcf.gz ${child_id}.${chrom}.vcf.gz.tbi ${child_id}.${chrom}.g.vcf.gz ${child_id}.${chrom}.g.vcf.gz.tbi
+    touch ${p1_id}.${chrom}.vcf.gz ${p1_id}.${chrom}.vcf.gz.tbi ${p1_id}.${chrom}.g.vcf.gz ${p1_id}.${chrom}.g.vcf.gz.tbi
+    touch ${p2_id}.${chrom}.vcf.gz ${p2_id}.${chrom}.vcf.gz.tbi ${p2_id}.${chrom}.g.vcf.gz ${p2_id}.${chrom}.g.vcf.gz.tbi
+    """
+}
+
+
+process bcftools_concat_deeptrio_vcfs {
+    tag { "${sample_id}" }
+    publishDir { "${params.deepvariant_output_dir}/DV_trio/${family_id}" }, mode: 'copy', overwrite: true
+
+    container "quay.io/biocontainers/bcftools:1.21--h8b25389_1"
+
+    input:
+        tuple val(family_id), val(sample_id), path(vcfs), path(tbis)
+
+    output:
+        tuple val(family_id), val(sample_id), path("${sample_id}.vcf.gz"), path("${sample_id}.vcf.gz.tbi"), emit: merged_vcf
+
+    script:
+    """
+    bcftools concat \
+        --allow-overlaps \
+        -Oz \
+        -o ${sample_id}.vcf.gz \
+        ${vcfs}
+
+    bcftools index -t ${sample_id}.vcf.gz
+    """
+
+    stub:
+    """
+    touch ${sample_id}.vcf.gz
+    touch ${sample_id}.vcf.gz.tbi
+    """
+}
+
+
+process bcftools_concat_deeptrio_gvcfs {
+    tag { "${sample_id}" }
+    publishDir { "${params.deepvariant_output_dir}/DV_trio/${family_id}" }, mode: 'copy', overwrite: true
+
+    container "quay.io/biocontainers/bcftools:1.21--h8b25389_1"
+
+    input:
+        tuple val(family_id), val(sample_id), path(gvcfs), path(tbis)
+
+    output:
+        tuple val(family_id), val(sample_id), path("${sample_id}.g.vcf.gz"), path("${sample_id}.g.vcf.gz.tbi"), emit: merged_gvcf
+
+    script:
+    """
+    bcftools concat \
+        --allow-overlaps \
+        -Oz \
+        -o ${sample_id}.g.vcf.gz \
+        ${gvcfs}
+
+    bcftools index -t ${sample_id}.g.vcf.gz
+    """
+
+    stub:
+    """
+    touch ${sample_id}.g.vcf.gz
+    touch ${sample_id}.g.vcf.gz.tbi
+    """
+}
+
+
 process glnexus_trio_merge {
     tag { "${family_id}" }
     publishDir { "${params.deepvariant_output_dir}/DV_trio/${family_id}" }, mode: 'copy', overwrite: true

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,19 @@ process {
     ext.model_type = 'PACBIO'
 }
 
+    withName: '^deeptrio_wgs_by_chrom$' {
+        queue = 'TowerForge-7hxrbYGSOMD6eweMBX4M90'
+        cpus = 16
+        memory = { 64.GB * task.attempt }
+        ext.model_type = 'PACBIO'
+    }
+
+    withName: '^(bcftools_concat_deeptrio_vcfs|bcftools_concat_deeptrio_gvcfs)$' {
+        queue = 'TowerForge-65jW9ftzynV2CSKqbQX8BN-work'
+        cpus = 4
+        memory = { 8.GB * task.attempt }
+    }
+
 
     withName: 'cpg_methylation_calling' {
         cpus          = 4


### PR DESCRIPTION
## Summary

This PR implements a scatter-gather pattern for DeepTrio WGS to run variant calling by chromosome rather than whole-genome in a single job. This improves parallelism and reduces per-job resource requirements.

## Changes

### New Processes (`modules/deepvariant/main.nf`)

- **`deeptrio_wgs_by_chrom`** — Runs DeepTrio with `--regions <chrom>` for a single chromosome. Produces per-chromosome VCF/gVCF for child and both parents.
- **`bcftools_concat_deeptrio_vcfs`** — Merges per-chromosome VCFs into a single per-sample VCF using `bcftools concat --allow-overlaps`.
- **`bcftools_concat_deeptrio_gvcfs`** — Same as above but for gVCF files (used by GLnexus downstream).

### Workflow Changes (`main.nf`)

- `WGS_TRIO` now scatters each trio across 24 chromosomes (chr1-22, chrX, chrY) using `combine()`
- Per-chromosome results are gathered with `groupTuple(by: [0, 1], size: 24)` and merged with bcftools
- Merged VCFs are routed back into the existing downstream processes (GLnexus, WhatsHap, HiPhase) with the same channel shapes

### Config (`nextflow.config`)

- `deeptrio_wgs_by_chrom`: 16 CPUs, 64 GB memory (per chrom — less than the previous 64 CPU whole-genome job)
- `bcftools_concat_deeptrio_vcfs` / `bcftools_concat_deeptrio_gvcfs`: 4 CPUs, 8 GB memory

## Benefits

- **Better parallelism**: 24 smaller jobs per trio instead of 1 large job
- **Faster wall-clock time**: Chromosomes run concurrently across the cluster
- **Lower per-job memory**: Each chromosome slice needs less RAM than the full genome
- **Improved retry granularity**: A failure on one chromosome doesn't require restarting the entire genome

## Downstream Compatibility

All downstream processes (GLnexus trio merge, WhatsHap phasing, HiPhase, CpG calling, SV calling) receive the same channel shapes as before — the merge step reconstitutes whole-genome per-sample VCFs before passing them downstream.